### PR TITLE
Misc Fixes

### DIFF
--- a/addon/decorators/controller-pagination.ts
+++ b/addon/decorators/controller-pagination.ts
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
 import { buildQueryParams, sortDirection } from '@gavant/ember-pagination/utils/query-params';
+import { setProperties } from '@ember/object';
 import { tryInvoke } from '@ember/utils';
 import { reject } from 'rsvp';
 import { A } from '@ember/array';
@@ -51,9 +52,10 @@ export default function controllerPagination<T extends ConcreteSubclass<any>>(Co
             try {
                 const result = await this.fetchModels(queryParams);
                 models = result.toArray();
-
-                this.metadata = result.meta;
-                this.set('hasMore', models.length >= limit);
+                setProperties(this, {
+                    metadata: result.meta,
+                    hasMore: models.length >= limit
+                });
 
                 tryInvoke(this.model, 'pushObjects', [models]);
             } catch(errors) {
@@ -63,46 +65,6 @@ export default function controllerPagination<T extends ConcreteSubclass<any>>(Co
             this.set('isLoadingPage', false);
             return models;
         }
-
-        // loadModelsTask: any = task(function * (this: PaginationController, reset: boolean, params: RouteParams) {
-        //     // get(this, 'loadingBar').start();
-        //     if(reset) {
-        //         this.clearModels();
-        //     }
-        //
-        //     const offset = this.offset;
-        //     const limit = this.limit;
-        //     const queryParams = buildQueryParams(this, params, offset, limit);
-        //     const result = yield this.fetchModels(queryParams);
-        //     const models = result.toArray();
-        //
-        //     this.metadata = result.meta;
-        //     this.hasMore = models.length >= limit;
-        //
-        //     tryInvoke(this.model, 'pushObjects', [models]);
-        //     // get(this, 'loadingBar').stop();
-        //     return models;
-        // }).restartable();
-
-        // @task(function * (this: PaginationController, reset: boolean, params: RouteParams) {
-        //     // get(this, 'loadingBar').start();
-        //     if(reset) {
-        //         this.clearModels();
-        //     }
-        //
-        //     const offset = this.offset;
-        //     const limit = this.limit;
-        //     const queryParams = buildQueryParams(this, params, offset, limit);
-        //     const result = yield this.fetchModels(queryParams);
-        //     const models = result.toArray();
-        //
-        //     this.metadata = result.meta;
-        //     this.hasMore = models.length >= limit;
-        //
-        //     tryInvoke(this.model, 'pushObjects', [models]);
-        //     // get(this, 'loadingBar').stop();
-        //     return models;
-        // }).restartable() loadModelsTask: any;
 
         fetchModels(queryParams: any) {
             const modelName = this.modelName as never;
@@ -178,7 +140,6 @@ export default function controllerPagination<T extends ConcreteSubclass<any>>(Co
         @action
         clearFilters() {
             this.serverQueryParams.forEach((param: string) => this.set(param, null));
-            // get(this, 'serverQueryParams').forEach((param) => set(this, param, null));
             return this.filterModels();
         }
     }

--- a/addon/decorators/route-pagination.ts
+++ b/addon/decorators/route-pagination.ts
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import { setProperties, set } from '@ember/object';
 import { assert } from '@ember/debug';
 import { PaginationController, buildQueryParams } from '@gavant/ember-pagination/utils/query-params';
 
@@ -11,9 +12,11 @@ export default function routePagination<T extends ConcreteSubclass<any>>(RouteSu
         setupController(controller: PaginationController, model: any) {
             assert('Model is not an instanceof DS.AdapterPopulatedRecordArray. In order to use the RoutePaginationMixin, the model returned must be an instance of DS.AdapterPopulatedRecordArray which comes from using store.query', model instanceof DS.AdapterPopulatedRecordArray);
 
-            controller.modelName = model.type.modelName;
-            controller.metadata = model.meta;
-            controller.hasMore = model.length >= controller.limit;
+            setProperties(controller, {
+                modelName: model.type.modelName,
+                metadata: model.meta,
+                hasMore: model.length >= controller.limit
+            });
 
             const modelForController = model.toArray();
             super.setupController(controller, modelForController);
@@ -39,7 +42,7 @@ export default function routePagination<T extends ConcreteSubclass<any>>(RouteSu
             super.resetController(controller, isExiting, transition);
 
             if (isExiting) {
-                controller.model = null;
+                set(controller, 'model', null);
             }
         }
 

--- a/addon/utils/query-params.ts
+++ b/addon/utils/query-params.ts
@@ -58,8 +58,9 @@ export function getParamsObject(parameters: [], context: PaginationController) {
                 valueKey = paramArray[1];
             }
             let value = get(context, valueKey);
-            if (moment.isMoment(value)) {
-                value = value.format('YYYY-MM-DDTHH:mm:ss');
+            if (moment.isMoment(value) || moment.isDate(value)) {
+                let serverDateFormat = getWithDefault(context, 'serverDateFormat', 'YYYY-MM-DDTHH:mm:ss');
+                value = moment(value).format(serverDateFormat);
             }
             params[key] = value;
         });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,9 @@
 {{#each model as |post|}}
+  <h1>
     {{post.title}}
+  </h1>
+  <p>
+    {{post.body}}
+  </p>
+  <hr>
 {{/each}}


### PR DESCRIPTION
- Without tracked properties, `set()` is still necessary with native class style modules -- updated existing direct class property assignments in the pagination decorators accordingly
- In addition to `moment()` objects, also serialize `Date` object query param values to strings
- Allow the serialized date format to be customized if needed
- remove some commented out code