### PR TITLE
Fix sort param

### DIFF
--- a/addon/utils/query-params.ts
+++ b/addon/utils/query-params.ts
@@ -33,8 +33,7 @@ export function buildQueryParams(
     let list: any = controller[queryParamListName];
     let queryParams = getParamsObject(list, controller);
     queryParams.offset = getWithDefault(controller, 'offset', offset);
-    queryParams.limit =  getWithDefault(controller, 'limit', limit);
-    queryParams.sort = getWithDefault(controller, 'sort', []);
+    queryParams.limit = getWithDefault(controller, 'limit', limit);
     return removeEmptyQueryParams(queryParams);
 }
 


### PR DESCRIPTION
`buildQueryParams()` was incorrectly re-setting the `sort` query param to the original array value, overwriting the string csv based value being set in `getParamsObject()`.